### PR TITLE
Change calldata length from 0 to 1

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -29,7 +29,7 @@ func execute(sourceFile string) {
 	context.ContractVariables = variables
 	context.Fee += (uint64(len(variables))) * 1000
 	context.Data = []byte{
-		0, // total bytes
+		1, // total bytes
 		0, // Contract Init Flag
 		//3,
 		//19, 70, 101, 78, // Function hash


### PR DESCRIPTION
We have modified the vm to use receive the exact length instead of length - 1. Therefore we had to change the length parameter or the calldata call when running our contract in the vm.