### PR TITLE
Handle unicode chars in string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bazo-blockchain/bazo-miner v0.0.0-20190202131416-70aeba0cc925
 	github.com/bazo-blockchain/bazo-vm v1.0.1-0.20190410195638-28694e495b6b
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/sys v0.0.0-20190410170021-cc4d4f50624c // indirect

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/bazo-blockchain/lazo/lexer/token"
+	"github.com/pkg/errors"
 	"io"
 	"log"
 	"math/big"
@@ -338,6 +339,10 @@ func (lex *Lexer) readEscapedLexeme(pred predicate, allowedCodes []rune) (string
 				lex.nextChar()
 				return string(buf), fmt.Errorf("escape code %c is not allowed", charToEscape)
 			}
+		} else if lex.current > 126 {
+			buf = append(buf, lex.current)
+			lex.nextChar()
+			return string(buf), errors.New("unicode char is not allowed")
 		} else {
 			buf = append(buf, lex.current)
 		}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -182,6 +182,11 @@ func TestNotClosedString(t *testing.T) {
 	tester.assertError(0, "not closed")
 }
 
+func TestUnicodeString(t *testing.T) {
+	tester := newLexerTestUtil(t, `"pound £"`)
+	tester.assertError(0, "pound £")
+}
+
 // Character Tokens
 // ----------------
 func TestCharacter(t *testing.T) {


### PR DESCRIPTION
Unicode chars (char code above 126) are not allowed in string
Control char 127 is deliberately ignored

Fixes https://github.com/bazo-blockchain/lazo/issues/19