### PR TITLE
Checker: Resolve Map Types

### DIFF
--- a/checker/checker_symbol_test.go
+++ b/checker/checker_symbol_test.go
@@ -123,6 +123,22 @@ func TestStructType(t *testing.T) {
 	tester.assertField(0, gs.Structs["Person"])
 }
 
+// Map Types
+//----------
+
+func TestMapType(t *testing.T) {
+	tester := newCheckerTestUtil(t, `
+		Map<String, int> map
+	`, true)
+
+	gs := tester.globalScope
+	assert.Equal(t, len(gs.Types), len(gs.BuiltInTypes)+1)
+
+	mapType := "Map<String,int>"
+	tester.assertMap(mapType, gs.StringType, gs.IntType)
+	tester.assertField(0, gs.Types[mapType])
+}
+
 // Constructor
 //------------
 

--- a/checker/checker_symbol_test.go
+++ b/checker/checker_symbol_test.go
@@ -139,6 +139,58 @@ func TestMapType(t *testing.T) {
 	tester.assertField(0, gs.Types[mapType])
 }
 
+func TestUniqueMapType(t *testing.T) {
+	tester := newCheckerTestUtil(t, `
+		Map<String, int> map
+		Map<String, int> map2
+	`, true)
+
+	gs := tester.globalScope
+	assert.Equal(t, len(gs.Types), len(gs.BuiltInTypes)+1)
+
+	mapType := "Map<String,int>"
+	tester.assertMap(mapType, gs.StringType, gs.IntType)
+	tester.assertField(0, gs.Types[mapType])
+	tester.assertField(1, gs.Types[mapType])
+}
+
+func TestInvalidMapType(t *testing.T) {
+	tester := newCheckerTestUtil(t, `
+		Map<None, int> map
+	`, false)
+
+	gs := tester.globalScope
+	assert.Equal(t, len(gs.Types), len(gs.BuiltInTypes))
+
+	tester.assertErrorAt(0, "Invalid type 'Map<None,int>'")
+	assert.Equal(t, gs.Contract.Fields[0].Type, nil)
+}
+
+func TestMapTypeWithStructType(t *testing.T) {
+	tester := newCheckerTestUtil(t, `
+		Map<int, Person> map
+
+		struct Person {
+		}
+	`, true)
+
+	gs := tester.globalScope
+
+	tester.assertMap("Map<int,Person>", gs.IntType, gs.Structs["Person"])
+	tester.assertField(0, gs.Types["Map<int,Person>"])
+}
+
+func TestMapTypeWithArrayType(t *testing.T) {
+	tester := newCheckerTestUtil(t, `
+		Map<int, int[][]> map
+	`, true)
+
+	gs := tester.globalScope
+
+	tester.assertMap("Map<int,int[][]>", gs.IntType, gs.Types["int[][]"])
+	tester.assertField(0, gs.Types["Map<int,int[][]>"])
+}
+
 // Constructor
 //------------
 

--- a/checker/checker_util_test.go
+++ b/checker/checker_util_test.go
@@ -109,14 +109,11 @@ func (ct *CheckerTestUtil) assertStructField(structName string, fieldIndex int, 
 
 func (ct *CheckerTestUtil) assertMap(mapName string, keyType symbol.TypeSymbol, valueType symbol.TypeSymbol) {
 	mapType := ct.globalScope.Types[mapName].(*symbol.MapTypeSymbol)
-	assert.Equal(ct.t, mapType.Scope(), ct.globalScope.Contract)
+	assert.Equal(ct.t, mapType.Scope(), ct.globalScope)
 	assert.Equal(ct.t, mapType.Identifier(), mapName)
 	assert.Equal(ct.t, mapType.KeyType, keyType)
-	assert.Equal(ct.t, mapType.ValueType, keyType)
+	assert.Equal(ct.t, mapType.ValueType, valueType)
 	assert.Equal(ct.t, len(mapType.AllDeclarations()), 0)
-
-	_, ok := ct.symbolTable.GetNodeBySymbol(mapType).(*node.MapTypeNode)
-	assert.Assert(ct.t, ok)
 }
 
 func (ct *CheckerTestUtil) assertConstructor(totalParams int, totalVars int) {

--- a/checker/checker_util_test.go
+++ b/checker/checker_util_test.go
@@ -107,6 +107,18 @@ func (ct *CheckerTestUtil) assertStructField(structName string, fieldIndex int, 
 	assert.Equal(ct.t, fieldSymbol.Identifier(), structFieldNode.Identifier)
 }
 
+func (ct *CheckerTestUtil) assertMap(mapName string, keyType symbol.TypeSymbol, valueType symbol.TypeSymbol) {
+	mapType := ct.globalScope.Types[mapName].(*symbol.MapTypeSymbol)
+	assert.Equal(ct.t, mapType.Scope(), ct.globalScope.Contract)
+	assert.Equal(ct.t, mapType.Identifier(), mapName)
+	assert.Equal(ct.t, mapType.KeyType, keyType)
+	assert.Equal(ct.t, mapType.ValueType, keyType)
+	assert.Equal(ct.t, len(mapType.AllDeclarations()), 0)
+
+	_, ok := ct.symbolTable.GetNodeBySymbol(mapType).(*node.MapTypeNode)
+	assert.Assert(ct.t, ok)
+}
+
 func (ct *CheckerTestUtil) assertConstructor(totalParams int, totalVars int) {
 	functionSymbol := ct.symbolTable.GlobalScope.Contract.Constructor
 	assert.Equal(ct.t, functionSymbol.Scope(), ct.symbolTable.GlobalScope.Contract)

--- a/checker/symbol/symbol_table.go
+++ b/checker/symbol/symbol_table.go
@@ -45,7 +45,7 @@ func (t *SymbolTable) AddArrayType(elementTypeNode node.TypeNode) TypeSymbol {
 	}
 
 	arrayType := NewArrayTypeSymbol(t.GlobalScope, elementType)
-	t.GlobalScope.Types[arrayType.Type()] = arrayType
+	t.GlobalScope.Types[arrayType.Identifier()] = arrayType
 	return arrayType
 }
 

--- a/checker/symbol/symbol_table.go
+++ b/checker/symbol/symbol_table.go
@@ -23,18 +23,23 @@ func NewSymbolTable() *SymbolTable {
 	}
 }
 
-// FindTypeByNode searches for a type
-// Returns the type or nil
-func (t *SymbolTable) FindTypeByNode(n node.TypeNode) TypeSymbol {
-	if typeSymbol := t.FindTypeByIdentifier(n.String()); typeSymbol != nil {
+// FindTypeByNode searches for a type symbol.
+// If an array type or map type are not found, they will be added to the global types.
+func (t *SymbolTable) FindTypeByNode(typeNode node.TypeNode) TypeSymbol {
+	if typeSymbol := t.FindTypeByIdentifier(typeNode.Type()); typeSymbol != nil {
 		return typeSymbol
 	}
 
-	if arrayType, ok := n.(*node.ArrayTypeNode); ok {
+	switch typeNode.(type) {
+	case *node.ArrayTypeNode:
+		arrayType := typeNode.(*node.ArrayTypeNode)
 		return t.AddArrayType(arrayType.ElementType)
+	case *node.MapTypeNode:
+		mapType := typeNode.(*node.MapTypeNode)
+		return t.AddMapType(mapType)
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 // AddArrayType creates a new array type symbol and adds it to the global types
@@ -47,6 +52,21 @@ func (t *SymbolTable) AddArrayType(elementTypeNode node.TypeNode) TypeSymbol {
 	arrayType := NewArrayTypeSymbol(t.GlobalScope, elementType)
 	t.GlobalScope.Types[arrayType.Identifier()] = arrayType
 	return arrayType
+}
+
+// AddMapType creates a new map type and adds it to the global scope types
+func (t *SymbolTable) AddMapType(mapTypeNode *node.MapTypeNode) TypeSymbol {
+	keyType := t.FindTypeByNode(mapTypeNode.KeyType)
+	valueType := t.FindTypeByNode(mapTypeNode.ValueType)
+
+	// To create a map type, both types should be valid
+	if keyType == nil || valueType == nil {
+		return nil
+	}
+
+	mapType := NewMapTypeSymbol(t.GlobalScope, keyType, valueType)
+	t.GlobalScope.Types[mapType.Identifier()] = mapType
+	return mapType
 }
 
 // FindTypeByIdentifier searches for a type

--- a/checker/symbol/symbols.go
+++ b/checker/symbol/symbols.go
@@ -97,11 +97,6 @@ func (sym *ContractSymbol) String() string {
 		sym.ID, sym.Fields, sym.Constructor, sym.Functions)
 }
 
-// Type returns the type
-func (sym *ContractSymbol) Type() string {
-	return sym.Identifier()
-}
-
 //----------------
 
 // FieldSymbol contains the type of the field
@@ -251,7 +246,6 @@ func (sym *ConstantSymbol) String() string {
 // TypeSymbol declares functions which all type symbols should implement
 type TypeSymbol interface {
 	Symbol
-	Type() string
 }
 
 //----------------
@@ -273,11 +267,6 @@ func (sym *BasicTypeSymbol) String() string {
 	return fmt.Sprintf("Type %s", sym.ID)
 }
 
-// Type returns the type
-func (sym *BasicTypeSymbol) Type() string {
-	return sym.Identifier()
-}
-
 //----------------
 
 // ArrayTypeSymbol represents a array type
@@ -289,7 +278,7 @@ type ArrayTypeSymbol struct {
 // NewArrayTypeSymbol creates a new ArrayTypeSymbol
 func NewArrayTypeSymbol(scope Symbol, elementType TypeSymbol) *ArrayTypeSymbol {
 	return &ArrayTypeSymbol{
-		AbstractSymbol: NewAbstractSymbol(scope, elementType.Type()+"[]"),
+		AbstractSymbol: NewAbstractSymbol(scope, elementType.Identifier()+"[]"),
 		ElementType:    elementType,
 	}
 }
@@ -297,11 +286,6 @@ func NewArrayTypeSymbol(scope Symbol, elementType TypeSymbol) *ArrayTypeSymbol {
 // String creates a new string representation
 func (sym *ArrayTypeSymbol) String() string {
 	return fmt.Sprintf("Array of %s", sym.ElementType)
-}
-
-// Type returns the type
-func (sym *ArrayTypeSymbol) Type() string {
-	return sym.Identifier()
 }
 
 //----------------
@@ -333,11 +317,6 @@ func (sym *StructTypeSymbol) String() string {
 	return fmt.Sprintf("Struct: %s, \nFields: %s", sym.Identifier(), sym.Fields)
 }
 
-// Type returns the struct type
-func (sym *StructTypeSymbol) Type() string {
-	return sym.Identifier()
-}
-
 // GetField returns the field symbol by identifier
 func (sym *StructTypeSymbol) GetField(identifier string) *FieldSymbol {
 	for _, f := range sym.Fields {
@@ -356,4 +335,28 @@ func (sym *StructTypeSymbol) GetFieldIndex(identifier string) int {
 		}
 	}
 	return -1
+}
+
+//----------------
+
+// MapTypeSymbol represents a map type consists of key and value type
+type MapTypeSymbol struct {
+	AbstractSymbol
+	KeyType   TypeSymbol
+	ValueType TypeSymbol
+}
+
+// NewMapTypeSymbol creates a new ArrayTypeSymbol
+func NewMapTypeSymbol(scope Symbol, keyType TypeSymbol, valueType TypeSymbol) *MapTypeSymbol {
+	return &MapTypeSymbol{
+		AbstractSymbol: NewAbstractSymbol(scope,
+			fmt.Sprintf("Map<%s,%s>", keyType.Identifier(), valueType.Identifier())),
+		KeyType:   keyType,
+		ValueType: valueType,
+	}
+}
+
+// String creates a new string representation
+func (sym *MapTypeSymbol) String() string {
+	return sym.Identifier()
 }

--- a/parser/node/nodes.go
+++ b/parser/node/nodes.go
@@ -46,6 +46,7 @@ type DesignatorNode interface {
 // TypeNode is the interface for types, such as array types or basic types
 type TypeNode interface {
 	Node
+	Type() string
 }
 
 // Concrete Nodes
@@ -288,6 +289,11 @@ func (n *BasicTypeNode) Accept(v Visitor) {
 	v.VisitBasicTypeNode(n)
 }
 
+// Type returns the unique type representation
+func (n *BasicTypeNode) Type() string {
+	return n.Identifier
+}
+
 // --------------------------
 
 // ArrayTypeNode composes abstract node and holds the type identifier.
@@ -305,6 +311,11 @@ func (n *ArrayTypeNode) Accept(v Visitor) {
 	v.VisitArrayTypeNode(n)
 }
 
+// Type returns the unique type representation
+func (n *ArrayTypeNode) Type() string {
+	return n.String()
+}
+
 // --------------------------
 
 // MapTypeNode composes abstract node and holds the types of key and value.
@@ -315,12 +326,17 @@ type MapTypeNode struct {
 }
 
 func (n *MapTypeNode) String() string {
-	return fmt.Sprintf("Map<%s, %s>", n.KeyType, n.ValueType)
+	return fmt.Sprintf("Map<%s,%s>", n.KeyType, n.ValueType)
 }
 
 // Accept lets a visitor to traverse its node structure
 func (n *MapTypeNode) Accept(v Visitor) {
 	v.VisitMapTypeNode(n)
+}
+
+// Type returns the unique type representation
+func (n *MapTypeNode) Type() string {
+	return n.String()
 }
 
 // --------------------------

--- a/parser/node/nodes_test.go
+++ b/parser/node/nodes_test.go
@@ -18,3 +18,51 @@ func TestContractNode_String(t *testing.T) {
 	assert.Equal(t, contract.String(),
 		"[1:1] CONTRACT Test \n FIELDS: [] \n\n STRUCTS: [] \n\n CONSTRUCTOR:  \n\n FUNCS: []")
 }
+
+// Type Nodes
+// ----------
+
+func TestBasicTypeNode_Type(t *testing.T) {
+	basicType := &BasicTypeNode{
+		Identifier: "int",
+	}
+
+	assert.Equal(t, basicType.Type(), "int")
+}
+
+func TestArrayTypeNode_Type(t *testing.T) {
+	basicType := &BasicTypeNode{
+		Identifier: "int",
+	}
+	arrayType := &ArrayTypeNode{
+		ElementType: basicType,
+	}
+
+	assert.Equal(t, arrayType.Type(), "int[]")
+}
+
+func TestArrayTypeNode_Type_2D(t *testing.T) {
+	basicType := &BasicTypeNode{
+		Identifier: "int",
+	}
+	arrayType := &ArrayTypeNode{
+		ElementType: basicType,
+	}
+	arrayType2D := &ArrayTypeNode{
+		ElementType: arrayType,
+	}
+
+	assert.Equal(t, arrayType2D.Type(), "int[][]")
+}
+
+func TestMapTypeNode_Type(t *testing.T) {
+	basicType := &BasicTypeNode{
+		Identifier: "int",
+	}
+	mapType := &MapTypeNode{
+		KeyType:   basicType,
+		ValueType: basicType,
+	}
+
+	assert.Equal(t, mapType.Type(), "Map<int,int>")
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -512,7 +512,10 @@ func (p *Parser) parseType() node.TypeNode {
 	if p.isSymbol(token.Map) {
 		return p.parseMapType()
 	}
-	return p.newErrorNode("Invalid type")
+
+	p.addError("Invalid type")
+	p.nextToken()
+	return nil
 }
 
 func (p *Parser) parseTypeWithIdentifier(abstractNode node.AbstractNode, identifier string) node.TypeNode {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -272,7 +272,7 @@ func TestMapDeclaration(t *testing.T) {
 	p := newParserFromInput("Map<String, int> map \n")
 	f := p.parseField()
 
-	assertField(t, f, "Map<String, int>", "map", "")
+	assertField(t, f, "Map<String,int>", "map", "")
 	assertNoErrors(t, p)
 }
 
@@ -508,7 +508,7 @@ func TestMapVariableStatement(t *testing.T) {
 	p := newParserFromInput("Map<int, int> m \n")
 	v := p.parseStatement().(*node.VariableNode)
 
-	assertVariableStatement(t, v, "Map<int, int>", "m", "")
+	assertVariableStatement(t, v, "Map<int,int>", "m", "")
 }
 
 // Multi Local Variable Statements
@@ -564,9 +564,9 @@ func TestMultiMapVariableStatement(t *testing.T) {
 	mv, ok := p.parseVariableStatement().(*node.MultiVariableNode)
 
 	assert.Assert(t, ok)
-	assert.Equal(t, mv.Types[0].String(), "Map<int, int>")
+	assert.Equal(t, mv.Types[0].String(), "Map<int,int>")
 	assert.Equal(t, mv.Identifiers[0], "m")
-	assert.Equal(t, mv.Types[1].String(), "Map<int, int[]>")
+	assert.Equal(t, mv.Types[1].String(), "Map<int,int[]>")
 	assert.Equal(t, mv.Identifiers[1], "n")
 	assertFuncCall(t, mv.FuncCall, "call")
 	assertNoErrors(t, p)


### PR DESCRIPTION
Create map types (e.g. `Map<int, String>`) and add them to types in global scope.