### PR TITLE
Remove null type and null constant

### DIFF
--- a/checker/checker_symbol_test.go
+++ b/checker/checker_symbol_test.go
@@ -27,10 +27,9 @@ func TestGlobalScope(t *testing.T) {
 	assert.Equal(t, len(gs.Types), 4)
 	assert.Equal(t, len(gs.BuiltInTypes), 4)
 	assert.Equal(t, len(gs.BuiltInFunctions), 0)
-	assert.Equal(t, len(gs.Constants), 3)
+	assert.Equal(t, len(gs.Constants), 2)
 
 	// Built-in types
-	assert.Equal(t, gs.NullType.Identifier(), "@NULL")
 	assert.Equal(t, gs.BoolType.Identifier(), "bool")
 	assert.Equal(t, gs.CharType.Identifier(), "char")
 	assert.Equal(t, gs.StringType.Identifier(), "String")
@@ -39,7 +38,6 @@ func TestGlobalScope(t *testing.T) {
 	// Constants
 	assert.Equal(t, gs.TrueConstant.Identifier(), "true")
 	assert.Equal(t, gs.FalseConstant.Identifier(), "false")
-	assert.Equal(t, gs.NullConstant.Identifier(), "null")
 }
 
 // Contract Symbol

--- a/checker/symbol/global_scope.go
+++ b/checker/symbol/global_scope.go
@@ -13,7 +13,6 @@ type GlobalScope struct {
 	Constants        []*ConstantSymbol
 	Structs          map[string]*StructTypeSymbol
 
-	NullType   *BasicTypeSymbol
 	BoolType   *BasicTypeSymbol
 	CharType   *BasicTypeSymbol
 	StringType *BasicTypeSymbol
@@ -26,12 +25,10 @@ type GlobalScope struct {
 
 	TrueConstant  *ConstantSymbol
 	FalseConstant *ConstantSymbol
-	NullConstant  *ConstantSymbol
 }
 
 func newGlobalScope() *GlobalScope {
 	gs := &GlobalScope{}
-	gs.NullType = NewBasicTypeSymbol(gs, "@NULL")
 	gs.Structs = make(map[string]*StructTypeSymbol)
 	gs.Types = make(map[string]TypeSymbol)
 

--- a/checker/symbolconstruction/symbol_construction.go
+++ b/checker/symbolconstruction/symbol_construction.go
@@ -58,7 +58,6 @@ func (sc *symbolConstruction) registerBuiltInType(name string) *symbol.BasicType
 }
 
 func (sc *symbolConstruction) registerBuiltInConstants() {
-	sc.globalScope.NullConstant = sc.registerBuiltInConstant(sc.globalScope.NullType, "null")
 	sc.globalScope.FalseConstant = sc.registerBuiltInConstant(sc.globalScope.BoolType, "false")
 	sc.globalScope.TrueConstant = sc.registerBuiltInConstant(sc.globalScope.BoolType, "true")
 }


### PR DESCRIPTION
Remove unused null type and constant.
null keyword is not required when reference types are default initialized.